### PR TITLE
docs: Fix readme formatting and heading hierarchy

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -264,7 +264,7 @@ curl -X POST “http://{*robot_ip_address*}:31950/sessions/{*session_id*}/comman
 
 ### Python
 
-```shell
+```python
 requests.post(
     url=f”http://{robot_ip_address}:31950/sessions/{session_id}/commands/execute”,
     headers={“Opentrons-Version”: “2”},
@@ -339,6 +339,7 @@ requests.delete(
     url=f”http://{robot_ip_address}:31950/protocols/{protocol_id}”,
     headers={“Opentrons-Version”: “2”},
 )
+```
 
 # Complete example program
 

--- a/readme.md
+++ b/readme.md
@@ -55,20 +55,26 @@ Now, you can additionally upload, run, and interact with protocols entirely thro
 Please note: These features are in beta stage and therefore details might change. 
 
 # New Features
-# Protocol upload
+
+## Protocol upload
+
 Python and JSON protocols can be uploaded to the OT-2 using an HTTP API. Protocol files will reside on the OT-2’s file system until deleted or the OT-2 is turned off.
 
-# Protocol sessions
+## Protocol sessions
+
 A protocol session type has been added to the sessions endpoints. A protocol session is associated with an uploaded protocol. Protocols can be simulated and executed using session commands.
 
-# Support files
+## Support files
+
 Protocols uploaded using the HTTP API can include support files. These can be data files or other python files. Python protocols can use _open_ to access these files. 
 
-# Importing user modules in Python protocols
+## Importing user modules in Python protocols
+
 A python file uploaded as a support file can be imported in a Python protocol. This enables breaking up Python protocols into multiple files for easy code reuse. 
 
 
 # Audience
+
 We assume that you’re either already familiar with these things, or you can figure them out on your own.
 
 * How HTTP and JSON APIs generally work.
@@ -77,6 +83,7 @@ We assume that you’re either already familiar with these things, or you can fi
 If you’re not already familiar with these things, let us know. We won’t be able to provide detailed support, but we might be able to point you to some learning resources.
 
 # Sharing Feedback
+
 Share feedback by emailing  [beta@opentrons.com](applewebdata://2A956D69-64A2-432B-880B-381DED88BF33/beta@opentrons.com) .
 
 If you have any thoughts on the current API, or our  [future plans](https://coda.io/d/Opentrons-HTTP-Platform-API-Beta_di2AUgtv1iy/Future-plans_suIju)  for it, please share them! **We need your help to make this API great. ❤️**
@@ -89,7 +96,9 @@ We’d love to hear about:
 * Anything else on your mind!
 
 # Setting Up
+
 ## Update your Opentrons App and OT-2
+
 Make sure both your Opentrons App and OT-2 are on the latest software version.
 
 Perform the update  [as normal](https://support.opentrons.com/en/articles/1795303-get-started-update-your-ot-2) .
@@ -97,6 +106,7 @@ Perform the update  [as normal](https://support.opentrons.com/en/articles/179530
 You can check what the latest version is at  [https://github.com/Opentrons/opentrons/releases/latest](https://github.com/Opentrons/opentrons/releases/latest) .
 
 ## Enable the beta features
+
 Since these features are experimental, they’re disabled by default. Here’s how to enable them:
 
 1. From the **Robot** tab, go to your OT-2’s page.
@@ -107,48 +117,57 @@ Since these features are experimental, they’re disabled by default. Here’s h
 
 To restore the ability to upload protocols through the Opentrons App, turn off **Enable Experimental HTTP Protocol Sessions.** Feel free to toggle the setting whenever you need to.
 
-
 # Examples
+
 ## Requirements for these examples
+
 The software requirement for the examples is cURL or Python 3.7 with  [requests](https://requests.readthedocs.io/en/master/)  package. 
 
 Replace _{_**robot_ip_address**_}_ with the IP address of the OT-2 which is found in the Opentrons application’s **Connectivity** section. 
 
 ## Uploading a protocol
+
 To upload a protocol file called “my_protocol.py”. The response will contain a unique identifier for the protocol (_protocol_id)._
 
-cURL
-```
+### cURL
+
+```shell
 curl -X POST “http://{*robot_ip_address*}:31950/protocols” -H “Opentrons-Version: 2” -H  “accept: application/json” -H “Content-Type: multipart/form-data” -F “protocolFile=@my_protocol.py”
 ```
 
-Python
-```
-```
-## POST the file to OT-2
-```
+### Python
+
+POST the file to OT-2:
+
+```python
 response = requests.post(
     url=f”http://{robot_ip_address}:31950/protocols”,
     files=[(“protocolFile”, open(“my_protocol.py”, ‘rb’))],
     headers={“Opentrons-Version”: “2”},
 )
 ```
-## Extract the uploaded protocol id from the response
-```
+
+Extract the uploaded protocol id from the response:
+
+```python
 protocol_id = response.json()[‘data’][‘id’]
 ```
 
 ## Uploading a protocol with support files
+
 Uploading a protocol file called “my_protocol.py” with two data files called “my_data.csv” and “my_data.json”. 
 
-cURL
-```
+### cURL
+
+```shell
 curl -X POST “http://{*robot_ip_address*}:31950/protocols” -H “Opentrons-Version: 2” -H  “accept: application/json” -H  “Content-Type: multipart/form-data” -F “supportFiles=@my_data.csv” -F “supportFiles=@my_data.json” -F “protocolFile=@my_protocol.py”
 ```
 
-Python
- POST the files to OT-2
-```
+### Python
+
+POST the files to OT-2:
+
+```python
 response = requests.post(
     url=f”http://{robot_ip_address}:31950/protocols”,
     files=[(“protocolFile”, open(“my_protocol.py”, ‘rb’)),
@@ -157,18 +176,26 @@ response = requests.post(
     headers={“Opentrons-Version”: “2”},
 )
 ```
-## Extract the uploaded protocol id from the response
-protocol_id = response.json()[‘data’][‘id’]#
+
+Extract the uploaded protocol id from the response:
+
+```python
+protocol_id = response.json()[‘data’][‘id’]
+```
 
 ## Creating a protocol session
+
 Once a protocol is uploaded, a session must be created to run the protocol. The response will contain a unique identifier for the session (_session_id_).
 
-cURL
-```
+### cURL
+
+```shell
 curl -X POST “http://{*robot_ip_address*}:31950/sessions” -H “Opentrons-Version: 2” -H “accept: application/json” -H “Content-Type: application/json” -d “{\”data\”:{\”sessionType\”:\”protocol\”,\”createParams\”:{\”protocolId\”:\”{*protocol_id*}\”}}}”
 ```
-Python
-```
+
+### Python
+
+```python
 response = requests.post(
     url=f”http://{robot_ip_address}:31950/sessions”,
     json={
@@ -182,19 +209,26 @@ response = requests.post(
     headers={“Opentrons-Version”: “2”},
 )
 ```
-## Extract the session id from the response
-session_id = response.json()[‘data’][‘id’]
 
-## Sending protocol session commands
-Use the **session_id**to send commands to the protocol sessions.
+Extract the session id from the response:
+
+```python
+session_id = response.json()[‘data’][‘id’]
+```
+
+Then, use `session_id` to send commands to the protocol sessions.
 
 ## Run
-cURL
-```
+
+### cURL
+
+```shell
 curl -X POST “http://{*robot_ip_address*}:31950/sessions/{*session_id*}/commands/execute” -H “Opentrons-Version: 2” -H “accept: application/json” -H “Content-Type: application/json” -d “{\”data\”:{\”command\”:\”protocol.startRun\”,\”data\”:{}}}”
 ```
-Python
-```
+
+### Python
+
+```python
 requests.post(
     url=f”http://{robot_ip_address}:31950/sessions/{session_id}/commands/execute”,
     headers={“Opentrons-Version”: “2”},
@@ -203,27 +237,34 @@ requests.post(
 ```
 
 ## Pause
-cURL
-```
+
+### cURL
+
+```shell
 curl -X POST “http://{*robot_ip_address*}:31950/sessions/{*session_id*}/commands/execute” -H “Opentrons-Version: 2” -H “accept: application/json” -H “Content-Type: application/json” -d “{\”data\”:{\”command\”:\”protocol.pause\”,\”data\”:{}}}”
 ```
-Python
-```
+
+### Python
+
+```python
 requests.post(
     url=f”http://{robot_ip_address}:31950/sessions/{session_id}/commands/execute”,
     headers={“Opentrons-Version”: “2”},
     json={“data”: {“command”: “protocol.pause”, “data”: {}}}
 )
 ```
-  
+
 ## Resume
-cURL
-```
+
+### cURL
+
+```shell
 curl -X POST “http://{*robot_ip_address*}:31950/sessions/{*session_id*}/commands/execute” -H “Opentrons-Version: 2” -H “accept: application/json” -H “Content-Type: application/json” -d “{\”data\”:{\”command\”:\”protocol.resume\”,\”data\”:{}}}”
 ```
 
-Python
-```
+### Python
+
+```shell
 requests.post(
     url=f”http://{robot_ip_address}:31950/sessions/{session_id}/commands/execute”,
     headers={“Opentrons-Version”: “2”},
@@ -232,12 +273,16 @@ requests.post(
 ```
   
 ## Cancel
-cURL
-```
+
+### cURL
+
+```shell
 curl -X POST “http://{*robot_ip_address*}:31950/sessions/{*session_id*}/commands/execute” -H “Opentrons-Version: 2” -H “accept: application/json” -H “Content-Type: application/json” -d “{\”data\”:{\”command\”:\”protocol.cancel\”,\”data\”:{}}}”
 ```
-Python
-```
+
+### Python
+
+```python
 requests.post(
     url=f”http://{robot_ip_address}:31950/sessions/{session_id}/commands/execute”,
     headers={“Opentrons-Version”: “2”},
@@ -246,13 +291,16 @@ requests.post(
 ```
 
 ## Getting protocol session’s status
-cURL
-```
+
+### cURL
+
+```shell
 curl “http://{*robot_ip_address*}:31950/sessions/{*session_id*}” -H “Opentrons-Version: 2”
 ```
 
-Python
-```
+### Python
+
+```python
 response = requests.get(
     url=f”http://{robot_ip_address}:31950/sessions/{session_id}”,
     headers={“Opentrons-Version”: “2”},
@@ -260,36 +308,47 @@ response = requests.get(
 ```
 
 ## Deleting a protocol session
-cURL
-```
+
+### cURL
+
+```shell
 curl -X DELETE “http://{*robot_ip_address*}:31950/sessions/{*session_id*}” -H “Opentrons-Version: 2”
 ```
-Python
-```
+
+### Python
+
+```python
 requests.delete(
     url=f”http://{robot_ip_address}:31950/sessions/{session_id}”,
     headers={“Opentrons-Version”: “2”},
 )
 ```
+
 ## Deleting an uploaded protocol
-cURL
-```
+
+### cURL
+
+```shell
 curl -X DELETE “http://{*robot_ip_address*}:31950/protocols/{*protocol_id*}” -H “Opentrons-Version: 2”
 ```
 
-Python
-```
+### Python
+
+```python
 requests.delete(
     url=f”http://{robot_ip_address}:31950/protocols/{protocol_id}”,
     headers={“Opentrons-Version”: “2”},
 )
 
 # Complete example program
-This example uses  [basic transfer](https://docs.opentrons.com/v2/new_examples.html#basic-transfer)  sample protocol as the foundation, but utilizing new features.
-```
+
+This example uses the [basic transfer](https://docs.opentrons.com/v2/new_examples.html#basic-transfer) sample protocol as the foundation, but utilizing new features.
+
 ## Protocol
-Create a file called “basic_transfer.py” containing this data
-```
+
+Create a file called “basic_transfer.py” containing this data:
+
+```python
 from opentrons import protocol_api
 from helpers import load_config, pick_up_then_drop
 
@@ -312,9 +371,12 @@ def run(protocol: protocol_api.ProtocolContext):
             instrument.aspirate(ml, plate[transfer[‘source_well’]])
             instrument.dispense(ml, plate[transfer[‘target_well’]])
 ```
+
 ## Configuration File
+
 Create a file called “basic_transfer_config.json” containing
-```
+
+```json
 {
   “plate”: “corning_96_wellplate_360ul_flat”,
   “tiprack”: “opentrons_96_tiprack_300ul”,
@@ -332,31 +394,36 @@ Create a file called “basic_transfer_config.json” containing
 ```
 
 ## Python helpers
+
 Create a file called “helpers.py” containing this code.
-```
+
+```python
 import contextlib
 import json
 
 def load_config(name: str):
-    /“””Load a configuration file”””/
+    “””Load a configuration file”””
 with open(name, ‘rb’) as f:
         return json.load(f)
 
 @contextlib.contextmanager
 def pick_up_then_drop(instrument):
-    /“””Pick up then automatically drop the tip in a context manager”””/
-instrument.pick_up_tip()
+    “””Pick up then automatically drop the tip in a context manager”””
+    instrument.pick_up_tip()
     yield
     instrument.drop_tip()
+```
 
 # Python Run Script
+
 This script will upload the basic_transfer protocol along with the configuration and helper python module. It will then create protocol session and run the protocol. It will print out the final status of the protocol session when the run is completed. Finally, it will delete the session and the protocol.
 
+```python
 import requests
 import time
-```
-## Replace with actual OT2 address
-```
+
+
+# Replace with actual OT2 address
 ROBOT_IP_ADDRESS = “127.0.0.1”
 
 
@@ -461,14 +528,17 @@ def run_protocol(protocol_id: str):
 
 if __name__ == ‘__main__’:
     run()
-
 ```
 
 # Future Plans
+
 ## Analysis upon upload
-Protocols uploaded to /protocols endpoint will be immediately analyzed and validated. The labware, instruments, and modules required by the protocol will be returned in the JSON response. 
+
+Protocols uploaded to /protocols endpoint will be immediately analyzed and validated. The labware, instruments, and modules required by the protocol will be returned in the JSON response.
+
 Example upload response:
-```
+
+```json
 {
   "links": {
     "self": {
@@ -529,11 +599,12 @@ Example upload response:
     }
   }
 }
-
 ```
 
 ## Notifications
-The OT2 now has a pub/sub service: the notification server. Users can receive protocol events via a websocket or the python subscriber client from our notification-server package.
-## Custom Labware
-Uploading custom labware is not currently supported in the HTTP API, but will be in the near future.
 
+The OT2 now has a pub/sub service: the notification server. Users can receive protocol events via a websocket or the python subscriber client from our notification-server package.
+
+## Custom Labware
+
+Uploading custom labware is not currently supported in the HTTP API, but will be in the near future.

--- a/readme.md
+++ b/readme.md
@@ -127,12 +127,12 @@ Replace _{_**robot_ip_address**_}_ with the IP address of the OT-2 which is foun
 
 ## Uploading a protocol
 
-To upload a protocol file called “my_protocol.py”. The response will contain a unique identifier for the protocol (_protocol_id)._
+To upload a protocol file called "my_protocol.py". The response will contain a unique identifier for the protocol (_protocol_id)._
 
 ### cURL
 
 ```shell
-curl -X POST “http://{*robot_ip_address*}:31950/protocols” -H “Opentrons-Version: 2” -H  “accept: application/json” -H “Content-Type: multipart/form-data” -F “protocolFile=@my_protocol.py”
+curl -X POST "http://{*robot_ip_address*}:31950/protocols" -H "Opentrons-Version: 2" -H  "accept: application/json" -H "Content-Type: multipart/form-data" -F "protocolFile=@my_protocol.py"
 ```
 
 ### Python
@@ -141,9 +141,9 @@ POST the file to OT-2:
 
 ```python
 response = requests.post(
-    url=f”http://{robot_ip_address}:31950/protocols”,
-    files=[(“protocolFile”, open(“my_protocol.py”, ‘rb’))],
-    headers={“Opentrons-Version”: “2”},
+    url=f"http://{robot_ip_address}:31950/protocols",
+    files=[("protocolFile", open("my_protocol.py", ‘rb’))],
+    headers={"Opentrons-Version": "2"},
 )
 ```
 
@@ -155,12 +155,12 @@ protocol_id = response.json()[‘data’][‘id’]
 
 ## Uploading a protocol with support files
 
-Uploading a protocol file called “my_protocol.py” with two data files called “my_data.csv” and “my_data.json”. 
+Uploading a protocol file called "my_protocol.py" with two data files called "my_data.csv" and "my_data.json". 
 
 ### cURL
 
 ```shell
-curl -X POST “http://{*robot_ip_address*}:31950/protocols” -H “Opentrons-Version: 2” -H  “accept: application/json” -H  “Content-Type: multipart/form-data” -F “supportFiles=@my_data.csv” -F “supportFiles=@my_data.json” -F “protocolFile=@my_protocol.py”
+curl -X POST "http://{*robot_ip_address*}:31950/protocols" -H "Opentrons-Version: 2" -H  "accept: application/json" -H  "Content-Type: multipart/form-data" -F "supportFiles=@my_data.csv" -F "supportFiles=@my_data.json" -F "protocolFile=@my_protocol.py"
 ```
 
 ### Python
@@ -169,11 +169,11 @@ POST the files to OT-2:
 
 ```python
 response = requests.post(
-    url=f”http://{robot_ip_address}:31950/protocols”,
-    files=[(“protocolFile”, open(“my_protocol.py”, ‘rb’)),
-           (“supportFiles”, open(“my_data.csv”, ‘rb’)),
-           (“supportFiles”, open(“my_data.json”, ‘rb’))],
-    headers={“Opentrons-Version”: “2”},
+    url=f"http://{robot_ip_address}:31950/protocols",
+    files=[("protocolFile", open("my_protocol.py", ‘rb’)),
+           ("supportFiles", open("my_data.csv", ‘rb’)),
+           ("supportFiles", open("my_data.json", ‘rb’))],
+    headers={"Opentrons-Version": "2"},
 )
 ```
 
@@ -190,23 +190,23 @@ Once a protocol is uploaded, a session must be created to run the protocol. The 
 ### cURL
 
 ```shell
-curl -X POST “http://{*robot_ip_address*}:31950/sessions” -H “Opentrons-Version: 2” -H “accept: application/json” -H “Content-Type: application/json” -d “{\”data\”:{\”sessionType\”:\”protocol\”,\”createParams\”:{\”protocolId\”:\”{*protocol_id*}\”}}}”
+curl -X POST "http://{*robot_ip_address*}:31950/sessions" -H "Opentrons-Version: 2" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"data\":{\"sessionType\":\"protocol\",\"createParams\":{\"protocolId\":\"{*protocol_id*}\"}}}"
 ```
 
 ### Python
 
 ```python
 response = requests.post(
-    url=f”http://{robot_ip_address}:31950/sessions”,
+    url=f"http://{robot_ip_address}:31950/sessions",
     json={
-        “data”: {
-            “sessionType”: “protocol”,
-            “createParams”: {
-                “protocolId”: protocol_id
+        "data": {
+            "sessionType": "protocol",
+            "createParams": {
+                "protocolId": protocol_id
             }
         }
     },
-    headers={“Opentrons-Version”: “2”},
+    headers={"Opentrons-Version": "2"},
 )
 ```
 
@@ -223,16 +223,16 @@ Then, use `session_id` to send commands to the protocol sessions.
 ### cURL
 
 ```shell
-curl -X POST “http://{*robot_ip_address*}:31950/sessions/{*session_id*}/commands/execute” -H “Opentrons-Version: 2” -H “accept: application/json” -H “Content-Type: application/json” -d “{\”data\”:{\”command\”:\”protocol.startRun\”,\”data\”:{}}}”
+curl -X POST "http://{*robot_ip_address*}:31950/sessions/{*session_id*}/commands/execute" -H "Opentrons-Version: 2" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"data\":{\"command\":\"protocol.startRun\",\"data\":{}}}"
 ```
 
 ### Python
 
 ```python
 requests.post(
-    url=f”http://{robot_ip_address}:31950/sessions/{session_id}/commands/execute”,
-    headers={“Opentrons-Version”: “2”},
-    json={“data”: {“command”: “protocol.startRun”, “data”: {}}}
+    url=f"http://{robot_ip_address}:31950/sessions/{session_id}/commands/execute",
+    headers={"Opentrons-Version": "2"},
+    json={"data": {"command": "protocol.startRun", "data": {}}}
 )
 ```
 
@@ -241,16 +241,16 @@ requests.post(
 ### cURL
 
 ```shell
-curl -X POST “http://{*robot_ip_address*}:31950/sessions/{*session_id*}/commands/execute” -H “Opentrons-Version: 2” -H “accept: application/json” -H “Content-Type: application/json” -d “{\”data\”:{\”command\”:\”protocol.pause\”,\”data\”:{}}}”
+curl -X POST "http://{*robot_ip_address*}:31950/sessions/{*session_id*}/commands/execute" -H "Opentrons-Version: 2" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"data\":{\"command\":\"protocol.pause\",\"data\":{}}}"
 ```
 
 ### Python
 
 ```python
 requests.post(
-    url=f”http://{robot_ip_address}:31950/sessions/{session_id}/commands/execute”,
-    headers={“Opentrons-Version”: “2”},
-    json={“data”: {“command”: “protocol.pause”, “data”: {}}}
+    url=f"http://{robot_ip_address}:31950/sessions/{session_id}/commands/execute",
+    headers={"Opentrons-Version": "2"},
+    json={"data": {"command": "protocol.pause", "data": {}}}
 )
 ```
 
@@ -259,16 +259,16 @@ requests.post(
 ### cURL
 
 ```shell
-curl -X POST “http://{*robot_ip_address*}:31950/sessions/{*session_id*}/commands/execute” -H “Opentrons-Version: 2” -H “accept: application/json” -H “Content-Type: application/json” -d “{\”data\”:{\”command\”:\”protocol.resume\”,\”data\”:{}}}”
+curl -X POST "http://{*robot_ip_address*}:31950/sessions/{*session_id*}/commands/execute" -H "Opentrons-Version: 2" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"data\":{\"command\":\"protocol.resume\",\"data\":{}}}"
 ```
 
 ### Python
 
 ```python
 requests.post(
-    url=f”http://{robot_ip_address}:31950/sessions/{session_id}/commands/execute”,
-    headers={“Opentrons-Version”: “2”},
-    json={“data”: {“command”: “protocol.resume”, “data”: {}}}
+    url=f"http://{robot_ip_address}:31950/sessions/{session_id}/commands/execute",
+    headers={"Opentrons-Version": "2"},
+    json={"data": {"command": "protocol.resume", "data": {}}}
 )
 ```
   
@@ -277,16 +277,16 @@ requests.post(
 ### cURL
 
 ```shell
-curl -X POST “http://{*robot_ip_address*}:31950/sessions/{*session_id*}/commands/execute” -H “Opentrons-Version: 2” -H “accept: application/json” -H “Content-Type: application/json” -d “{\”data\”:{\”command\”:\”protocol.cancel\”,\”data\”:{}}}”
+curl -X POST "http://{*robot_ip_address*}:31950/sessions/{*session_id*}/commands/execute" -H "Opentrons-Version: 2" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"data\":{\"command\":\"protocol.cancel\",\"data\":{}}}"
 ```
 
 ### Python
 
 ```python
 requests.post(
-    url=f”http://{robot_ip_address}:31950/sessions/{session_id}/commands/execute”,
-    headers={“Opentrons-Version”: “2”},
-    json={“data”: {“command”: “protocol.cancel”, “data”: {}}}
+    url=f"http://{robot_ip_address}:31950/sessions/{session_id}/commands/execute",
+    headers={"Opentrons-Version": "2"},
+    json={"data": {"command": "protocol.cancel", "data": {}}}
 )
 ```
 
@@ -295,15 +295,15 @@ requests.post(
 ### cURL
 
 ```shell
-curl “http://{*robot_ip_address*}:31950/sessions/{*session_id*}” -H “Opentrons-Version: 2”
+curl "http://{*robot_ip_address*}:31950/sessions/{*session_id*}" -H "Opentrons-Version: 2"
 ```
 
 ### Python
 
 ```python
 response = requests.get(
-    url=f”http://{robot_ip_address}:31950/sessions/{session_id}”,
-    headers={“Opentrons-Version”: “2”},
+    url=f"http://{robot_ip_address}:31950/sessions/{session_id}",
+    headers={"Opentrons-Version": "2"},
 )
 ```
 
@@ -312,15 +312,15 @@ response = requests.get(
 ### cURL
 
 ```shell
-curl -X DELETE “http://{*robot_ip_address*}:31950/sessions/{*session_id*}” -H “Opentrons-Version: 2”
+curl -X DELETE "http://{*robot_ip_address*}:31950/sessions/{*session_id*}" -H "Opentrons-Version: 2"
 ```
 
 ### Python
 
 ```python
 requests.delete(
-    url=f”http://{robot_ip_address}:31950/sessions/{session_id}”,
-    headers={“Opentrons-Version”: “2”},
+    url=f"http://{robot_ip_address}:31950/sessions/{session_id}",
+    headers={"Opentrons-Version": "2"},
 )
 ```
 
@@ -329,15 +329,15 @@ requests.delete(
 ### cURL
 
 ```shell
-curl -X DELETE “http://{*robot_ip_address*}:31950/protocols/{*protocol_id*}” -H “Opentrons-Version: 2”
+curl -X DELETE "http://{*robot_ip_address*}:31950/protocols/{*protocol_id*}" -H "Opentrons-Version: 2"
 ```
 
 ### Python
 
 ```python
 requests.delete(
-    url=f”http://{robot_ip_address}:31950/protocols/{protocol_id}”,
-    headers={“Opentrons-Version”: “2”},
+    url=f"http://{robot_ip_address}:31950/protocols/{protocol_id}",
+    headers={"Opentrons-Version": "2"},
 )
 ```
 
@@ -347,7 +347,7 @@ This example uses the [basic transfer](https://docs.opentrons.com/v2/new_example
 
 ## Protocol
 
-Create a file called “basic_transfer.py” containing this data:
+Create a file called "basic_transfer.py" containing this data:
 
 ```python
 from opentrons import protocol_api
@@ -357,7 +357,7 @@ metadata = {‘apiLevel’: ‘2.6’}
 
 
 def run(protocol: protocol_api.ProtocolContext):
-    configuration = load_config(“basic_transfer_config.json”)
+    configuration = load_config("basic_transfer_config.json")
 
     plate = protocol.load_labware(configuration[‘plate’], 1)
     tiprack_1 = protocol.load_labware(configuration[‘tiprack’], 2)
@@ -375,41 +375,41 @@ def run(protocol: protocol_api.ProtocolContext):
 
 ## Configuration File
 
-Create a file called “basic_transfer_config.json” containing
+Create a file called "basic_transfer_config.json" containing
 
 ```json
 {
-  “plate”: “corning_96_wellplate_360ul_flat”,
-  “tiprack”: “opentrons_96_tiprack_300ul”,
-  “instrument”: {
-    “model”: “p300_single”,
-    “mount”: “right”
+  "plate": "corning_96_wellplate_360ul_flat",
+  "tiprack": "opentrons_96_tiprack_300ul",
+  "instrument": {
+    "model": "p300_single",
+    "mount": "right"
   },
-  “transfers”: [
+  "transfers": [
     {
-      “source_well”: “A1”,
-      “target_well”: “B1”,
-      “ml”: 100
+      "source_well": "A1",
+      "target_well": "B1",
+      "ml": 100
     }]
 }
 ```
 
 ## Python helpers
 
-Create a file called “helpers.py” containing this code.
+Create a file called "helpers.py" containing this code.
 
 ```python
 import contextlib
 import json
 
 def load_config(name: str):
-    “””Load a configuration file”””
+    """Load a configuration file"""
 with open(name, ‘rb’) as f:
         return json.load(f)
 
 @contextlib.contextmanager
 def pick_up_then_drop(instrument):
-    “””Pick up then automatically drop the tip in a context manager”””
+    """Pick up then automatically drop the tip in a context manager"""
     instrument.pick_up_tip()
     yield
     instrument.drop_tip()
@@ -425,20 +425,20 @@ import time
 
 
 # Replace with actual OT2 address
-ROBOT_IP_ADDRESS = “127.0.0.1”
+ROBOT_IP_ADDRESS = "127.0.0.1"
 
 
 def run():
     # POST the protocol and support files to OT2
     response = requests.post(
-        url=f”http://{ROBOT_IP_ADDRESS}:31950/protocols”,
-        headers={“Opentrons-Version”: “2”},
-        files=[(“protocolFile”, open(“basic_transfer.py”, ‘rb’)),
-               (“supportFiles”, open(“helpers.py”, ‘rb’)),
-               (“supportFiles”, open(“basic_transfer_config.json”, ‘rb’)),
+        url=f"http://{ROBOT_IP_ADDRESS}:31950/protocols",
+        headers={"Opentrons-Version": "2"},
+        files=[("protocolFile", open("basic_transfer.py", ‘rb’)),
+               ("supportFiles", open("helpers.py", ‘rb’)),
+               ("supportFiles", open("basic_transfer_config.json", ‘rb’)),
                ]
     )
-    print(f”Create Protocol result: {response.json()}”)
+    print(f"Create Protocol result: {response.json()}")
 
     # Extract the uploaded protocol id from the response
     protocol_id = response.json()[‘data’][‘id’]
@@ -446,33 +446,33 @@ def run():
     try:
         errors = response.json()[‘data’].get(‘errors’)
         if errors:
-            raise RuntimeError(f”Errors in protocol: {errors}”)
+            raise RuntimeError(f"Errors in protocol: {errors}")
 
         run_protocol(protocol_id)
 
     finally:
         # Use the protocol_id to DELETE the protocol
         requests.delete(
-            url=f”http://{ROBOT_IP_ADDRESS}:31950/protocols/{protocol_id}”,
-            headers={“Opentrons-Version”: “2”},
+            url=f"http://{ROBOT_IP_ADDRESS}:31950/protocols/{protocol_id}",
+            headers={"Opentrons-Version": "2"},
         )
 
 
 def run_protocol(protocol_id: str):
     # Create a protocol session
     response = requests.post(
-        url=f”http://{ROBOT_IP_ADDRESS}:31950/sessions”,
-        headers={“Opentrons-Version”: “2”},
+        url=f"http://{ROBOT_IP_ADDRESS}:31950/sessions",
+        headers={"Opentrons-Version": "2"},
         json={
-            “data”: {
-                “sessionType”: “protocol”,
-                “createParams”: {
-                    “protocolId”: protocol_id
+            "data": {
+                "sessionType": "protocol",
+                "createParams": {
+                    "protocolId": protocol_id
                 }
             }
         }
     )
-    print(f”Create Session result: {response.json()}”)
+    print(f"Create Session result: {response.json()}")
     # Extract the session id from the response
     session_id = response.json()[‘data’][‘id’]
 
@@ -484,21 +484,21 @@ def run_protocol(protocol_id: str):
             time.sleep(.5)
 
             response = requests.get(
-                url=f”http://{ROBOT_IP_ADDRESS}:31950/sessions/{session_id}”,
-                headers={“Opentrons-Version”: “2”},
+                url=f"http://{ROBOT_IP_ADDRESS}:31950/sessions/{session_id}",
+                headers={"Opentrons-Version": "2"},
             )
 
             current_state = response.json()[‘data’][‘details’][‘currentState’]
             if current_state == ‘loaded’:
                 break
             elif current_state == ‘error’:
-                raise RuntimeError(f”Error encountered {response.json()}”)
+                raise RuntimeError(f"Error encountered {response.json()}")
 
         # Send a command to begin a protocol run
         requests.post(
-            url=f”http://{ROBOT_IP_ADDRESS}:31950/sessions/{session_id}/commands/execute”,
-            headers={“Opentrons-Version”: “2”},
-            json={“data”: {“command”: “protocol.startRun”, “data”: {}}}
+            url=f"http://{ROBOT_IP_ADDRESS}:31950/sessions/{session_id}/commands/execute",
+            headers={"Opentrons-Version": "2"},
+            json={"data": {"command": "protocol.startRun", "data": {}}}
         )
 
         # Wait until session is in the ‘finished’ state
@@ -507,23 +507,23 @@ def run_protocol(protocol_id: str):
             time.sleep(.5)
 
             response = requests.get(
-                url=f”http://{ROBOT_IP_ADDRESS}:31950/sessions/{session_id}”,
-                headers={“Opentrons-Version”: “2”},
+                url=f"http://{ROBOT_IP_ADDRESS}:31950/sessions/{session_id}",
+                headers={"Opentrons-Version": "2"},
             )
 
             current_state = response.json()[‘data’][‘details’][‘currentState’]
             if current_state == ‘finished’:
-                print(“Run is complete:”)
+                print("Run is complete:")
                 print(response.json())
                 break
             elif current_state == ‘error’:
-                raise RuntimeError(f”Error encountered {response.json()}”)
+                raise RuntimeError(f"Error encountered {response.json()}")
 
     finally:
         # Use the session_id to DELETE the session
         requests.delete(
-            url=f”http://{ROBOT_IP_ADDRESS}:31950/sessions/{session_id}”,
-            headers={“Opentrons-Version”: “2”},
+            url=f"http://{ROBOT_IP_ADDRESS}:31950/sessions/{session_id}",
+            headers={"Opentrons-Version": "2"},
         )
 
 

--- a/readme.md
+++ b/readme.md
@@ -3,45 +3,6 @@
 > ### Curious to access the early HTTP API?
 > [Use this form to apply for the beta program](https://opentrons-ux.typeform.com/to/WxFIa8vs)
 
-- [Opentrons HTTP Platform API Beta](#opentrons-http-platform-api-beta)
-  * [New Features](#new-features)
-  * [Protocol upload](#protocol-upload)
-  * [Protocol sessions](#protocol-sessions)
-  * [Support files](#support-files)
-  * [Importing user modules in Python protocols](#importing-user-modules-in-python-protocols)
-- [Audience](#audience)
-- [Sharing Feedback](#sharing-feedback)
-- [Setting Up](#setting-up)
-  * [Update your Opentrons App and OT-2](#update-your-opentrons-app-and-ot-2)
-  * [Enable the beta features](#enable-the-beta-features)
-- [Examples](#examples)
-  * [Requirements for these examples](#requirements-for-these-examples)
-  * [Uploading a protocol](#uploading-a-protocol)
-  * [POST the file to OT-2](#post-the-file-to-ot-2)
-  * [Extract the uploaded protocol id from the response](#extract-the-uploaded-protocol-id-from-the-response)
-  * [Uploading a protocol with support files](#uploading-a-protocol-with-support-files)
-  * [Extract the uploaded protocol id from the response](#extract-the-uploaded-protocol-id-from-the-response-1)
-  * [Creating a protocol session](#creating-a-protocol-session)
-  * [Extract the session id from the response](#extract-the-session-id-from-the-response)
-  * [Sending protocol session commands](#sending-protocol-session-commands)
-  * [Run](#run)
-  * [Pause](#pause)
-  * [Resume](#resume)
-  * [Cancel](#cancel)
-  * [Getting protocol session’s status](#getting-protocol-session-s-status)
-  * [Deleting a protocol session](#deleting-a-protocol-session)
-  * [Deleting an uploaded protocol](#deleting-an-uploaded-protocol)
-  * [Protocol](#protocol)
-  * [Configuration File](#configuration-file)
-  * [Python helpers](#python-helpers)
-  * [Replace with actual OT2 address](#replace-with-actual-ot2-address)
-- [Future Plans](#future-plans)
-  * [Analysis upon upload](#analysis-upon-upload)
-  * [Notifications](#notifications)
-  * [Custom Labware](#custom-labware)
-
-
-
 Version 4.0 of the OT-2 robot software introduces a number of features that provide greater flexibility in protocol execution. 
 
 Prior to this version, to run a protocol on the OT-2, you needed to use:


### PR DESCRIPTION
Close #1.

* Fix some mis-nested/interleaved headings.
* Add syntax highlighting to all code blocks.
* Replace typographer's quotes with ASCII quotes.
* Delete the manually written table of contents, since the GitHub UI provides its own.